### PR TITLE
bizhawk: Bandage null SRAM peeking

### DIFF
--- a/src/platform/bizhawk/bizinterface.c
+++ b/src/platform/bizhawk/bizinterface.c
@@ -354,6 +354,11 @@ EXP void BizGetMemoryAreas(bizctx* ctx, struct MemoryAreas* dst)
 	dst->oam = ctx->core->getMemoryBlock(ctx->core, REGION_OAM, &sizeOut);
 	dst->rom = ctx->core->getMemoryBlock(ctx->core, REGION_CART0, &sizeOut);
 	dst->sram = ctx->core->getMemoryBlock(ctx->core, REGION_CART_SRAM_MIRROR, &dst->sram_size);
+	// Quick fix to NullReferenceException; natt's old code
+	if (!dst->sram)
+	{
+		dst->sram = ctx->sram;
+	}
 }
 
 EXP int BizGetSaveRam(bizctx* ctx, void* data, int size)


### PR DESCRIPTION
This is a fix for https://github.com/TASVideos/BizHawk/issues/1620. Ideally, we would sort out why `getMemoryBlock()` doesn't work for SaveRAM in these specific instances, but it's probably better to have a fallback like this than to allow the emulator to crash when certain perfectly valid memory peeks are made.